### PR TITLE
Remove the Deno hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,9 +40,3 @@ repos:
     hooks:
       - id: shellcheck
         args: ["-e", "SC1071,SC1072,SC1073,SC1090,SC1091,SC2015,SC2148,SC2154"]
-
-  - repo: https://github.com/nozaq/pre-commit-deno
-    rev: 0.1.0
-    hooks:
-      - id: deno-fmt
-      - id: deno-lint


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

**Issue:** close #

### Checklist

- [ ] This Pull Request introduces a new feature.
- [ ] This Pull Request fixes a bug.

### Description

Because pre-commit.ci can't install Deno runtime.

<!--
A clear and concise description
  - Why did you make this change?
  - Please describe how this method is better than others.
-->

<br />

- [x] I agree to follow the [Code of Conduct](https://github.com/5ouma/opml-generator/blob/main/.github/CODE_OF_CONDUCT.md).
