### PR TITLE
Add `Type: Dependencies` label to pre-commit.ci

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -15,6 +15,6 @@
 "Type: CI":
   - head-branch: ["^ci-"]
 "Type: Dependencies":
-  - head-branch: ["^dep(endency|endencies|s)?-"]
+  - head-branch: ["^dep(endency|endencies|s)?-", "^pre-commit-ci-update-config$"]
 "Type: Meta":
   - head-branch: ["^meta-"]


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

**Issue:** close #

### Checklist

- [ ] This Pull Request introduces a new feature.
- [ ] This Pull Request fixes a bug.

### Description

When hooks are updated, automatically add that label.

<!--
A clear and concise description
  - Why did you make this change?
  - Please describe how this method is better than others.
-->

<br />

- [x] I agree to follow the [Code of Conduct](https://github.com/5ouma/opml-generator/blob/main/.github/CODE_OF_CONDUCT.md).
