### PR TITLE
Pin Deno dependency versions for Molt

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -7,11 +7,11 @@
     "test": "deno test --allow-read --allow-write"
   },
   "imports": {
-    "@libs/xml": "jsr:@libs/xml@^5.0.2",
-    "@std/assert": "jsr:@std/assert@^0.225.2",
-    "@std/cli": "jsr:@std/cli@^0.224.2",
-    "@std/path": "jsr:@std/path@^0.225.1",
-    "@std/toml": "jsr:@std/toml@^0.224.0",
-    "@wok/case": "jsr:@wok/case@^1.0.1"
+    "@libs/xml": "jsr:@libs/xml@5.0.2",
+    "@std/assert": "jsr:@std/assert@0.225.2",
+    "@std/cli": "jsr:@std/cli@0.224.2",
+    "@std/path": "jsr:@std/path@0.225.1",
+    "@std/toml": "jsr:@std/toml@0.224.0",
+    "@wok/case": "jsr:@wok/case@1.0.1"
   }
 }

--- a/deno.lock
+++ b/deno.lock
@@ -3,14 +3,14 @@
   "packages": {
     "specifiers": {
       "jsr:@libs/typing@2": "jsr:@libs/typing@2.0.3",
-      "jsr:@libs/xml@^5.0.2": "jsr:@libs/xml@5.0.2",
-      "jsr:@std/assert@^0.225.2": "jsr:@std/assert@0.225.2",
-      "jsr:@std/cli@^0.224.2": "jsr:@std/cli@0.224.2",
-      "jsr:@std/collections@^0.224.0": "jsr:@std/collections@0.224.2",
-      "jsr:@std/internal@^0.225.1": "jsr:@std/internal@0.225.1",
-      "jsr:@std/path@^0.225.1": "jsr:@std/path@0.225.1",
-      "jsr:@std/toml@^0.224.0": "jsr:@std/toml@0.224.0",
-      "jsr:@wok/case@^1.0.1": "jsr:@wok/case@1.0.1"
+      "jsr:@libs/xml@5.0.2": "jsr:@libs/xml@5.0.2",
+      "jsr:@std/assert@0.225.2": "jsr:@std/assert@0.225.2",
+      "jsr:@std/cli@0.224.2": "jsr:@std/cli@0.224.2",
+      "jsr:@std/collections@0.224.0": "jsr:@std/collections@0.224.2",
+      "jsr:@std/internal@0.225.1": "jsr:@std/internal@0.225.1",
+      "jsr:@std/path@0.225.1": "jsr:@std/path@0.225.1",
+      "jsr:@std/toml@0.224.0": "jsr:@std/toml@0.224.0",
+      "jsr:@wok/case@1.0.1": "jsr:@wok/case@1.0.1"
     },
     "jsr": {
       "@libs/typing@2.0.3": {
@@ -60,12 +60,12 @@
   "remote": {},
   "workspace": {
     "dependencies": [
-      "jsr:@libs/xml@^5.0.2",
-      "jsr:@std/assert@^0.225.2",
-      "jsr:@std/cli@^0.224.2",
-      "jsr:@std/path@^0.225.1",
-      "jsr:@std/toml@^0.224.0",
-      "jsr:@wok/case@^1.0.1"
+      "jsr:@libs/xml@5.0.2",
+      "jsr:@std/assert@0.225.2",
+      "jsr:@std/cli@0.224.2",
+      "jsr:@std/path@0.225.1",
+      "jsr:@std/toml@0.224.0",
+      "jsr:@wok/case@1.0.1"
     ]
   }
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### ⚠️ Issue

close #

<br />

### ✔︎ Checklists

- [ ] This Pull Request introduces a new feature.
- [ ] This Pull Request fixes a bug.

<br />

### 🔄 Type of the Change

- [ ] 🎉 Feature
- [ ] 🧰 Bug
- [ ] 🛡️ Security
- [ ] 📖 Documentation
- [ ] 🧹 Refactoring
- [ ] 🧪 Testing
- [ ] 🔧 Maintenance
- [x] 🎽 CI
- [x] ⛓️ Dependencies
- [ ] 🧠 Meta

<br />

### ✏️ Description

That's because Molt doesn't update packages which is specified with ambiguous specifies.

<!--
A clear and concise description
  - Why did you make this change?
  - Please describe how this method is better than others.
-->

<br />

- [x] I agree to follow the [Code of Conduct](https://github.com/5ouma/opml-generator/blob/main/.github/CODE_OF_CONDUCT.md).
