### PR TITLE
Remove `./` from GitHub Actions workflows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,12 +7,12 @@ on:
       - dev
     paths:
       - "**.ts"
-      - "./deno.lock"
+      - "deno.lock"
       - ".github/workflows/test.yml"
   pull_request:
     paths:
       - "**.ts"
-      - "./deno.lock"
+      - "deno.lock"
       - ".github/workflows/test.yml"
 
 jobs:


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### ⚠️ Issue

close #

<br />

### ✔︎ Checklists

- [ ] This Pull Request introduces a new feature.
- [ ] This Pull Request fixes a bug.

<br />

### 🔄 Type of the Change

- [ ] 🎉 Feature
- [ ] 🧰 Bug
- [ ] 🛡️ Security
- [ ] 📖 Documentation
- [ ] 🧹 Refactoring
- [ ] 🧪 Testing
- [ ] 🔧 Maintenance
- [x] 🎽 CI
- [ ] ⛓️ Dependencies
- [ ] 🧠 Meta

<br />

### ✏️ Description

GitHub Actions probably doesn't recognize the syntax.

<!--
A clear and concise description
  - Why did you make this change?
  - Please describe how this method is better than others.
-->

<br />

- [x] I agree to follow the [Code of Conduct](https://github.com/5ouma/opml-generator/blob/main/.github/CODE_OF_CONDUCT.md).
