### PR TITLE
Inject RSS query correctly

### DIFF
--- a/src/libs/utils/sites.ts
+++ b/src/libs/utils/sites.ts
@@ -4,19 +4,19 @@ type site = {
 };
 
 const sites: site[] = [
-  { type: "bluesky", url: new URL("https://bsky.app/profile/{id}/rss") },
+  { type: "bluesky", url: new URL("https://bsky.app/profile/id/rss") },
   {
     type: "nitter",
     url: new URL(
       `https://${
         Deno.env.get("NITTER_DOMAIN") ?? "cdn.xcancel.com"
-      }/search/rss?f=tweets&q={id}`,
+      }/search/rss?f=tweets&q=id`,
     ),
   },
-  { type: "note", url: new URL("https://note.com/{id}/rss") },
-  { type: "reddit", url: new URL("https://www.reddit.com/r/{id}/.rss") },
-  { type: "sizu.me", url: new URL("https://sizu.me/{id}/rss") },
-  { type: "zenn", url: new URL("https://zenn.dev/{id}/feed") },
+  { type: "note", url: new URL("https://note.com/id/rss") },
+  { type: "reddit", url: new URL("https://www.reddit.com/r/id/.rss") },
+  { type: "sizu.me", url: new URL("https://sizu.me/id/rss") },
+  { type: "zenn", url: new URL("https://zenn.dev/id/feed") },
 ];
 
 export function transcodeXmlUrl(
@@ -31,7 +31,5 @@ export function transcodeXmlUrl(
     .find((site: site) => site.type === type)?.url;
   if (!url) throw new Error(`site not found: "${type}" of "${title}"`);
 
-  return new URL(
-    url.href.replace(encodeURI("{id}"), id).replaceAll("%3F", "?"),
-  );
+  return new URL(url.href.replace("id", id));
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### ⚠️ Issue

close #

<br />

### 🔄 Type of the Change

- [ ] 🎉 New Feature
- [x] 🧰 Bug
- [ ] 🛡️ Security
- [ ] 📖 Documentation
- [ ] 🏎️ Performance
- [ ] 🧹 Refactoring
- [ ] 🧪 Testing
- [ ] 🔧 Maintenance
- [ ] 🎽 CI
- [ ] ⛓️ Dependencies
- [ ] 🧠 Meta

<br />

### ✏️ Description

The Nitter URL wasn't replaced with `id`.

<!--
A clear and concise description
  - Why did you make this change?
  - Please describe how this method is better than others.
-->

<br />

- [x] I agree to follow the [Code of Conduct](https://github.com/5ouma/opml-generator/blob/main/.github/CODE_OF_CONDUCT.md).
