### PR TITLE
Make TOML and XML functions as modules

### DIFF
--- a/src/libs/mod.ts
+++ b/src/libs/mod.ts
@@ -1,3 +1,3 @@
-export * from "./toml/io.ts";
-export * from "./xml/io.ts";
+export * as toml from "./toml/io.ts";
+export * as xml from "./xml/io.ts";
 export type { Lists } from "./types.ts";

--- a/src/libs/toml/io.test.ts
+++ b/src/libs/toml/io.test.ts
@@ -1,6 +1,6 @@
 import { assertEquals, assertIsError } from "@std/assert";
 
-import { readTOML } from "./io.ts";
+import { read } from "./io.ts";
 import type { Lists } from "../types.ts";
 
 Deno.test("Read TOML", async (t: Deno.TestContext) => {
@@ -27,12 +27,12 @@ xmlUrl = "https://example.com/feed"
     const file: string = await Deno.makeTempFile({ suffix: ".toml" });
     await Deno.writeTextFile(file, toml);
 
-    assertEquals(await readTOML(file), lists);
+    assertEquals(await read(file), lists);
   });
 
   await t.step("file not found", async () => {
     try {
-      await readTOML("file-not-found.toml");
+      await read("file-not-found.toml");
     } catch (error) {
       assertEquals(error.message, 'file not found: "file-not-found.toml"');
     }
@@ -42,7 +42,7 @@ xmlUrl = "https://example.com/feed"
     const file: string = await Deno.makeTempFile({ suffix: ".toml" });
     await Deno.chmod(file, 0o000);
     try {
-      await readTOML(file);
+      await read(file);
     } catch (error) {
       assertEquals(error.message, `permission denied: "${file}"`);
     }
@@ -50,7 +50,7 @@ xmlUrl = "https://example.com/feed"
 
   await t.step("unexpected error", async () => {
     try {
-      await readTOML("");
+      await read("");
     } catch (error) {
       assertIsError(error);
     }

--- a/src/libs/toml/io.ts
+++ b/src/libs/toml/io.ts
@@ -1,7 +1,7 @@
 import { convert } from "./convert.ts";
 import type { Lists } from "../types.ts";
 
-export async function readTOML(file: string): Promise<Lists> {
+export async function read(file: string): Promise<Lists> {
   try {
     const data: string = await Deno.readTextFile(file);
     return convert(data);

--- a/src/libs/xml/io.test.ts
+++ b/src/libs/xml/io.test.ts
@@ -1,7 +1,7 @@
 import { assertEquals } from "@std/assert";
 import { join } from "@std/path";
 
-import { writeXML } from "./io.ts";
+import { write } from "./io.ts";
 import type { Lists } from "../types.ts";
 
 Deno.test("Write XML", async () => {
@@ -25,7 +25,7 @@ Deno.test("Write XML", async () => {
 `;
 
   const dir: string = await Deno.makeTempDir();
-  await writeXML(lists, dir);
+  await write(lists, dir);
 
   assertEquals(await Deno.readTextFile(join(dir, "list-name.xml")), xml);
 });

--- a/src/libs/xml/io.ts
+++ b/src/libs/xml/io.ts
@@ -4,7 +4,7 @@ import { format } from "@std/path";
 import { convert } from "./convert.ts";
 import type { List, Lists } from "../types.ts";
 
-export async function writeXML(feeds: Lists, dir: string): Promise<void> {
+export async function write(feeds: Lists, dir: string): Promise<void> {
   await Deno.mkdir(dir, { recursive: true });
   feeds.lists.map(async (list: List) => {
     const file: string = format({

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,21 +1,18 @@
 import { parseArgs } from "@std/cli";
 import { basename, resolve } from "@std/path";
 
-import { type Lists, readTOML, writeXML } from "./libs/mod.ts";
+import { type Lists, toml, xml } from "./libs/mod.ts";
 
 const flags = parseArgs(Deno.args, {
   string: ["feeds", "output"],
-  default: {
-    feeds: "./feeds.toml",
-    output: "./outputs",
-  },
+  default: { feeds: "./feeds.toml", output: "./outputs" },
 });
 flags.feeds = resolve(flags.feeds);
 flags.output = resolve(flags.output);
 
 try {
-  const feeds: Lists = await readTOML(flags.feeds);
-  await writeXML(feeds, flags.output);
+  const feeds: Lists = await toml.read(flags.feeds);
+  await xml.write(feeds, flags.output);
 } catch (error) {
   console.error(`🚨 ${error.message}`);
   Deno.exit(1);


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### ⚠️ Issue

close #

<br />

### 🔄 Type of the Change

- [ ] 🎉 New Feature
- [ ] 🧰 Bug
- [ ] 🛡️ Security
- [ ] 📖 Documentation
- [ ] 🏎️ Performance
- [x] 🧹 Refactoring
- [ ] 🧪 Testing
- [ ] 🔧 Maintenance
- [ ] 🎽 CI
- [ ] ⛓️ Dependencies
- [ ] 🧠 Meta

<br />

### ✏️ Description

It makes the function names clean and easy to use.

<!--
A clear and concise description
  - Why did you make this change?
  - Please describe how this method is better than others.
-->

<br />

- [x] I agree to follow the [Code of Conduct](https://github.com/5ouma/opml-generator/blob/main/.github/CODE_OF_CONDUCT.md).
