### PR TITLE
Use tagpr to prepare releasing

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,7 +17,6 @@ close #
 - [ ] 🧪 Testing
 - [ ] 🔧 Maintenance
 - [ ] 🎽 CI
-- [ ] ⛓️ Dependencies
 - [ ] 🧠 Meta
 
 <br />

--- a/.github/pr-labeler.yml
+++ b/.github/pr-labeler.yml
@@ -1,6 +1,4 @@
 alwaysReplace: true
-searchTitle: true
-searchBody: true
 
 customLabels:
   - text: "- [x] 🎉 New Feature"
@@ -21,11 +19,9 @@ customLabels:
     label: 🔧 Maintenance
   - text: "- [x] 🎽 CI"
     label: 🎽 CI
-  - text: "- [x] ⛓️ Dependencies"
-    label: ⛓️ Dependencies
   - text: "chore(deps): "
     label: ⛓️ Dependencies
   - text: "- [x] 🧠 Meta"
     label: 🧠 Meta
-  - text: Release v
+  - text: Release for v
     label: 🚀 Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,13 +4,12 @@ on:
   push:
     branches:
       - main
-    paths:
-      - deno.json
   workflow_dispatch:
 
 permissions:
   contents: write
   id-token: write
+  pull-requests: write
 
 jobs:
   Release:
@@ -19,24 +18,13 @@ jobs:
     steps:
       - name: 🚚 Checkout Repository
         uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
-        with:
-          fetch-depth: 0
 
-      - name: 🔍 Check the Version
-        id: version
-        run: |
-          version="$(jq -r '.version' deno.json)"
-          tag="$(git tag -l | sort -V | tail -n 1)"
-          if [[ "v$version" != "$tag" ]]; then
-            echo "next=v$version" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: 🚀 Release a New Version
-        if: ${{ steps.version.outputs.next != '' }}
-        run: gh release create "${{ steps.version.outputs.next }}" --generate-notes
+      - name: 🏷️ Release a New Version
+        id: tagpr
+        uses: Songmu/tagpr@591c6e0c988bccee7dda02bce1af7a3b2dc47065 # v1.4.2
         env:
-          GH_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: 📦 Publish to JSR
-        if: ${{ steps.version.outputs.next != '' }}
+        if: ${{ steps.tagpr.outputs.tag != '' }}
         run: npx jsr publish

--- a/.tagpr
+++ b/.tagpr
@@ -1,0 +1,7 @@
+[tagpr]
+  releaseBranch = main
+  versionFile = deno.json
+  vPrefix = true
+  changelog = false
+  majorLabels = 🧨 Breaking Change
+  minorLabels = 🎉 New Feature


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### ⚠️ Issue

close #

<br />

### 🔄 Type of the Change

- [ ] 🎉 New Feature
- [ ] 🧰 Bug
- [ ] 🛡️ Security
- [ ] 📖 Documentation
- [ ] 🏎️ Performance
- [ ] 🧹 Refactoring
- [ ] 🧪 Testing
- [ ] 🔧 Maintenance
- [x] 🎽 CI
- [ ] ⛓️ Dependencies
- [ ] 🧠 Meta

<br />

### ✏️ Description

Automatically open a PR and bumping the deno.json.

<!--
A clear and concise description
  - Why did you make this change?
  - Please describe how this method is better than others.
-->

<br />

- [x] I agree to follow the
      [Code of Conduct](https://github.com/5ouma/opml-generator/blob/main/.github/CODE_OF_CONDUCT.md).
