### PR TITLE
Add XML attributes to the object to be stringified

### DIFF
--- a/src/libs/xml/convert.test.ts
+++ b/src/libs/xml/convert.test.ts
@@ -11,8 +11,7 @@ Deno.test("Convert Lists to OPML", async (t: Deno.TestContext) => {
   <body>
     <outline title="feed title" text="feed title" xmlUrl="https://example.com/feed" type="rss"/>
   </body>
-</opml>
-`;
+</opml>`;
 
     const list: List = {
       name: "list name",
@@ -32,8 +31,7 @@ Deno.test("Convert Lists to OPML", async (t: Deno.TestContext) => {
   <body>
     <outline title="feed title" text="feed title" xmlUrl="https://bsky.app/profile/username/rss" type="rss"/>
   </body>
-</opml>
-`;
+</opml>`;
 
     const list: List = {
       name: "list name",

--- a/src/libs/xml/convert.ts
+++ b/src/libs/xml/convert.ts
@@ -38,7 +38,9 @@ export function convert(list: List): string {
     }),
   };
 
-  return `<?xml version="1.0" encoding="UTF-8"?>
-${stringify({ opml: { "@version": "2.0", body: [body] } })}
-`;
+  return stringify({
+    "@version": "1.0",
+    "@encoding": "UTF-8",
+    opml: { "@version": "2.0", body: [body] },
+  });
 }

--- a/src/libs/xml/io.test.ts
+++ b/src/libs/xml/io.test.ts
@@ -21,8 +21,7 @@ Deno.test("Write XML", async () => {
   <body>
     <outline title="feed title" text="feed title" xmlUrl="https://example.com/feed" type="rss"/>
   </body>
-</opml>
-`;
+</opml>`;
 
   const dir: string = await Deno.makeTempDir();
   await write(lists, dir);


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### ⚠️ Issue

close #

<br />

### ✏️ Description

The @libs/xml treats the root attributes itself.

<!--
A clear and concise description
  - Why did you make this change?
  - Please describe how this method is better than others.
-->

<br />

- [x] I agree to follow the [Code of Conduct].

[Code of Conduct]: https://github.com/5ouma/opml-generator/blob/main/.github/CODE_OF_CONDUCT.md
