### PR TITLE
Make the XML URL as string

### DIFF
--- a/src/libs/toml/convert.test.ts
+++ b/src/libs/toml/convert.test.ts
@@ -19,7 +19,7 @@ xmlUrl = "https://example.com/feed"
         name: "list name",
         feeds: [{
           title: "feed title",
-          xmlUrl: new URL("https://example.com/feed"),
+          xmlUrl: "https://example.com/feed",
         }],
       }],
     };
@@ -45,7 +45,7 @@ id = "username"
           title: "feed title",
           type: "bluesky",
           id: "username",
-          xmlUrl: new URL("https://bsky.app/profile/username/rss"),
+          xmlUrl: "https://bsky.app/profile/username/rss",
         }],
       }],
     };

--- a/src/libs/toml/convert.ts
+++ b/src/libs/toml/convert.ts
@@ -29,9 +29,7 @@ export function convert(data: string): Lists {
   const lists: Lists = parse(data) as Lists;
   lists.lists.map((list: List) => {
     list.feeds.map((feed: Feed) => {
-      feed.xmlUrl = feed.xmlUrl
-        ? feed.xmlUrl
-        : transcodeXmlUrl(feed.title, feed.type, feed.id);
+      feed.xmlUrl ??= transcodeXmlUrl(feed.title, feed.type, feed.id);
     });
   });
   return lists;

--- a/src/libs/toml/convert.ts
+++ b/src/libs/toml/convert.ts
@@ -30,7 +30,7 @@ export function convert(data: string): Lists {
   lists.lists.map((list: List) => {
     list.feeds.map((feed: Feed) => {
       feed.xmlUrl = feed.xmlUrl
-        ? new URL(feed.xmlUrl)
+        ? feed.xmlUrl
         : transcodeXmlUrl(feed.title, feed.type, feed.id);
     });
   });

--- a/src/libs/toml/io.test.ts
+++ b/src/libs/toml/io.test.ts
@@ -19,7 +19,7 @@ xmlUrl = "https://example.com/feed"
         name: "list name",
         feeds: [{
           title: "feed title",
-          xmlUrl: new URL("https://example.com/feed"),
+          xmlUrl: "https://example.com/feed",
         }],
       }],
     };

--- a/src/libs/types.ts
+++ b/src/libs/types.ts
@@ -55,7 +55,7 @@ export type List = {
  * ```ts
  * const feed: Feed = {
  *   title: "Feed Title",
- *   xmlUrl: new URL("https://example.com/feed.xml")
+ *   xmlUrl: "https://example.com/feed.xml"
  * }
  * ```
  */
@@ -63,7 +63,7 @@ export type Feed = {
   title: string;
   type?: string;
   id?: string;
-  xmlUrl?: URL;
+  xmlUrl?: string;
 };
 
 /**
@@ -79,7 +79,7 @@ export type Feed = {
  * const outline: OPMLOutline = {
  *   "@title": "Outline Title",
  *   "@text": "Outline Text",
- *   "@xmlUrl": new URL("https://example.com/feed.xml"),
+ *   "@xmlUrl": "https://example.com/feed.xml",
  *   "@type": "rss"
  * }
  * ```
@@ -87,6 +87,6 @@ export type Feed = {
 export type OPMLOutline = {
   "@title": string;
   "@text": string;
-  "@xmlUrl": URL;
+  "@xmlUrl": string;
   "@type": "rss";
 };

--- a/src/libs/utils/sites.test.ts
+++ b/src/libs/utils/sites.test.ts
@@ -13,7 +13,7 @@ Deno.test("Get XML URL", async (t: Deno.TestContext) => {
 
     assertEquals(
       transcodeXmlUrl(feed.title, feed.type, feed.id),
-      new URL("https://bsky.app/profile/username/rss"),
+      "https://bsky.app/profile/username/rss",
     );
   });
 

--- a/src/libs/utils/sites.ts
+++ b/src/libs/utils/sites.ts
@@ -60,14 +60,14 @@ const sites: site[] = [
  *
  * @example
  * ```ts
- * const url: URL = transcodeXmlUrl("feed title", "bluesky", "username");
+ * const url: string = transcodeXmlUrl("feed title", "bluesky", "username");
  * ```
  */
 export function transcodeXmlUrl(
   title: string,
   type: string | undefined,
   id: string | undefined,
-): URL {
+): string {
   if (!type) throw new Error(`parameter not set: "type" of "${title}"`);
   if (!id) throw new Error(`parameter not set: "id" of "${title}"`);
 
@@ -75,5 +75,5 @@ export function transcodeXmlUrl(
     .find((site: site) => site.type === type)?.url;
   if (!url) throw new Error(`site not found: "${type}" of "${title}"`);
 
-  return new URL(url.href.replace("id", id));
+  return url.href.replace("id", id);
 }

--- a/src/libs/xml/convert.test.ts
+++ b/src/libs/xml/convert.test.ts
@@ -17,7 +17,7 @@ Deno.test("Convert Lists to OPML", async (t: Deno.TestContext) => {
       name: "list name",
       feeds: [{
         title: "feed title",
-        xmlUrl: new URL("https://example.com/feed"),
+        xmlUrl: "https://example.com/feed",
       }],
     };
 

--- a/src/libs/xml/convert.ts
+++ b/src/libs/xml/convert.ts
@@ -30,9 +30,8 @@ export function convert(list: List): string {
       return {
         "@title": feed.title,
         "@text": feed.title,
-        "@xmlUrl": feed.xmlUrl
-          ? feed.xmlUrl
-          : transcodeXmlUrl(feed.title, feed.type, feed.id),
+        "@xmlUrl": feed.xmlUrl ??
+          transcodeXmlUrl(feed.title, feed.type, feed.id),
         "@type": "rss",
       };
     }),

--- a/src/libs/xml/convert.ts
+++ b/src/libs/xml/convert.ts
@@ -18,7 +18,7 @@ import type { Feed, List, OPMLOutline } from "../types.ts";
  *   name: "list name",
  *   feeds: [{
  *     title: "feed title",
- *     xmlUrl: new URL("https://example.com/feed"),
+ *     xmlUrl: "https://example.com/feed",
  *   }],
  * };
  * const opml: string = convert(list);
@@ -31,7 +31,7 @@ export function convert(list: List): string {
         "@title": feed.title,
         "@text": feed.title,
         "@xmlUrl": feed.xmlUrl
-          ? new URL(feed.xmlUrl)
+          ? feed.xmlUrl
           : transcodeXmlUrl(feed.title, feed.type, feed.id),
         "@type": "rss",
       };

--- a/src/libs/xml/io.test.ts
+++ b/src/libs/xml/io.test.ts
@@ -10,7 +10,7 @@ Deno.test("Write XML", async () => {
       name: "list name",
       feeds: [{
         title: "feed title",
-        xmlUrl: new URL("https://example.com/feed"),
+        xmlUrl: "https://example.com/feed",
       }],
     }],
   };

--- a/src/libs/xml/io.ts
+++ b/src/libs/xml/io.ts
@@ -25,7 +25,7 @@ import type { List, Lists } from "../types.ts";
  *     name: "list name",
  *     feeds: [{
  *       title: "feed title",
- *       xmlUrl: new URL("https://example.com/feed"),
+ *       xmlUrl: "https://example.com/feed",
  *    }],
  *   }],
  * };


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### ⚠️ Issue

close #

<br />

### ✏️ Description

There's no need to make them URL objects.

<!--
A clear and concise description
  - Why did you make this change?
  - Please describe how this method is better than others.
-->

<br />

- [x] I agree to follow the [Code of Conduct].

[Code of Conduct]: https://github.com/5ouma/opml-generator/blob/main/.github/CODE_OF_CONDUCT.md
