### PR TITLE
Use GitHub App token instead of default token

### DIFF
--- a/.github/ghalint.yml
+++ b/.github/ghalint.yml
@@ -1,4 +1,0 @@
-excludes:
-  - policy_name: checkout_persist_credentials_should_be_false
-    workflow_file_path: .github/workflows/release.yml
-    job_name: tagpr

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,16 @@ jobs:
       - name: 🚚 Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          persist-credentials: true
+          persist-credentials: false
+
+      - name: 💳 Create GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
 
       - name: 🏷️ Release a New Version
         id: tagpr
@@ -31,7 +40,7 @@ jobs:
         with:
           config: .github/tagpr.ini
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
   publish:
     name: 📦 Publish to JSR


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### ⚠️ Issue

close #

<br />

### ✏️ Description

It will fire workflows that can't be with the default token.

<!--
A clear and concise description
  - Why did you make this change?
  - Please describe how this method is better than others.
-->

<br />

- [x] I agree to follow the [Code of Conduct].

[Code of Conduct]: https://github.com/5ouma/opml-generator/blob/main/.github/CODE_OF_CONDUCT.md
