### PR TITLE
Make a temp dir for XML JSDoc

### DIFF
--- a/src/libs/xml/io.ts
+++ b/src/libs/xml/io.ts
@@ -29,7 +29,8 @@ import type { List, Lists } from "../types.ts";
  *    }],
  *   }],
  * };
- * await write(feeds, "outputs");
+ * const dir: string = await Deno.makeTempDir();
+ * await write(feeds, dir);
  * ```
  */
 export async function write(feeds: Lists, dir: string): Promise<void> {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### ⚠️ Issue

close #

<br />

### ✏️ Description

Deno test runs JSDoc, and it's super flaky.

<!--
A clear and concise description
  - Why did you make this change?
  - Please describe how this method is better than others.
-->

<br />

- [x] I agree to follow the [Code of Conduct].

[Code of Conduct]: https://github.com/5ouma/opml-generator/blob/main/.github/CODE_OF_CONDUCT.md
