### PR TITLE
Use the new permission set feature

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -6,10 +6,13 @@
     "include": ["LICENSE", "README.md", "deno.json", "src/"],
     "exclude": ["**/*.test.ts"]
   },
+  "permissions": {
+    "default": { "read": true, "write": true, "env": ["NITTER_DOMAIN"] }
+  },
   "lock": { "frozen": true },
   "tasks": {
-    "gen": "deno run -RWE='NITTER_DOMAIN' src/main.ts",
-    "test": "deno test --doc -RWE='NITTER_DOMAIN' --parallel --shuffle",
+    "gen": "deno run -P src/main.ts",
+    "test": "deno test -P --parallel --doc --shuffle",
     "test:cov": "deno task test --coverage --junit-path='junit.xml'"
   },
   "imports": {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### ⚠️ Issue

close #

<br />

### ✏️ Description

It can manage permissions without passing manually.

<!--
A clear and concise description
  - Why did you make this change?
  - Please describe how this method is better than others.
-->

<br />

- [x] I agree to follow the [Code of Conduct].

[Code of Conduct]: https://github.com/5ouma/opml-generator/blob/main/.github/CODE_OF_CONDUCT.md
