### PR TITLE
Use `deno x` command instead on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ OPML Generator has 2 ways to convert TOML to OPML.
 2. Run this command
 
    ```she
-   deno run -A jsr:@5ouma/opml-generator
+   deno x jsr:@5ouma/opml-generator
    ```
 
 3. Outputs are stored in the `outputs` directory separated by `lists`


### PR DESCRIPTION
### ⚠️ Issue <!-- rumdl-disable-line MD041 -->

close #

<br />

### ✏️ Description

It's shorter than the `deno run` command.

<!--
A clear and concise description
  - Why did you make this change?
  - Please describe how this method is better than others.
-->

<br />

- [x] I agree to follow the [Code of Conduct].

[Code of Conduct]: https://github.com/5ouma/opml-generator/blob/main/.github/CODE_OF_CONDUCT.md
